### PR TITLE
fix: cloned node should be synthesized

### DIFF
--- a/src/clone-node.test.ts
+++ b/src/clone-node.test.ts
@@ -3,6 +3,19 @@ import ts from "typescript";
 import { cloneNode } from "./clone-node.js";
 
 describe(cloneNode, () => {
+  it("should create a synthesized node", () => {
+    const orig: ts.Node = ts.factory.createIdentifier("hoge");
+    (orig as any).flags = 0;
+    const cloned = cloneNode(orig);
+    expect(cloned.flags & ts.NodeFlags.Synthesized).toBe(ts.NodeFlags.Synthesized);
+  });
+
+  it("should not link to original node", () => {
+    const orig: ts.Node = ts.factory.createIdentifier("hoge");
+    const cloned = cloneNode(orig);
+    expect(ts.getOriginalNode(cloned)).toBe(cloned);
+  });
+
   it("should copy from node", () => {
     const orig: ts.Node = ts.factory.createIdentifier("hoge");
     const cloned = cloneNode(orig);

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -1,14 +1,11 @@
 import ts from "typescript";
 
-type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+// Typescript undocumented API, see Ron Buckton's explaination why it's not public:
+// https://github.com/microsoft/TypeScript/issues/40507#issuecomment-737628756
+// But it's very fit our case
+const { cloneNode: _cloneNode } = ts.factory as any;
 
 export function cloneNode<T extends ts.Node>(node: T): T {
-  const props = { ...node } as Mutable<T>;
-  props.pos = -1;
-  props.end = -1;
-  const base = new (node as any).constructor();
-  Object.keys(props).forEach(k => {
-    base[k] = props[k as keyof T];
-  });
-  return base as T;
+  const cloned = _cloneNode(node);
+  return ts.setOriginalNode(cloned, undefined); // remove original
 }


### PR DESCRIPTION
This PR fix #166 .

Instead of naive fix described in the issue, I rewrite `cloneNode` implementation, use ts internal `ts.factory.cloneNode` which I believe would be more robust.